### PR TITLE
fix(utils): escape all chars on path

### DIFF
--- a/fnl/tangerine/utils/path.fnl
+++ b/fnl/tangerine/utils/path.fnl
@@ -28,7 +28,9 @@
 (lambda p.from-x-to-y [path [from ext1] [to ext2]]
   "changes 'path's extension and parent-dir from 'ext1' to 'ext2'."
   (let [from (env.get from)
+        from (from:gsub "%p" "%%%1")
         to   (env.get to)
+        to (to:gsub "%p" "%%%1")
         path (path:gsub (.. ext1 "$") ext2)]
        (if (vim.startswith path from)
            (path:gsub from to)


### PR DESCRIPTION
So my user config path linked from another path and after lua extends it to get the real path it looks like `/home/alex/dot-files/nvim/.config/nvim/` with a dash.

On the path to neovim user configs there may be dashes which lua interpellate as special symbols. This commit just escapes every character inside variables of paths.

Closes #21