### PR TITLE
[CI]: support luarocks/rocks.nvim

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,27 @@
+name: Luarocks
+
+on:
+  push:
+    tags:
+      - 'v*'
+  release:
+    types:
+      - created
+  pull_request: # Test this on PR without uploading
+  workflow_dispatch:
+
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required to get the tags
+      - name: Get Version
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}

--- a/README.md
+++ b/README.md
@@ -53,9 +53,13 @@
 1. Create file `plugin/0-tangerine.lua` to bootstrap tangerine:
 
 > [!IMPORTANT]
-> If you are using [lazy.nvim](https://github.com/folke/lazy.nvim) then you should create `init.lua` instead of `plugin/0-tangerine.lua`.
 >
-> Refer to [#20](https://github.com/udayvir-singh/tangerine.nvim/issues/20) for more information.
+> - If you are using [lazy.nvim](https://github.com/folke/lazy.nvim) then you should create `init.lua` instead of `plugin/0-tangerine.lua`.
+>   Refer to [#20](https://github.com/udayvir-singh/tangerine.nvim/issues/20) for more information.
+>
+> - If you are using [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), there is no need to bootstrap this plugin
+>   (unless you want to write your rocks.nvim bootstrap script in Fennel).
+>   Install with `:Rocks install tangerine.nvim` and skip to step 2.
 
 ```lua
 -- ~/.config/nvim/plugin/0-tangerine.lua or ~/.config/nvim/init.lua

--- a/doc/tangerine.txt
+++ b/doc/tangerine.txt
@@ -55,10 +55,14 @@ ANISEED
 
 1. Create file `plugin/0-tangerine.lua` to bootstrap tangerine:
 
-[!IMPORTANT] If you are using lazy.nvim <https://github.com/folke/lazy.nvim>
-then you should create `init.lua` instead of `plugin/0-tangerine.lua`. > Refer
-to #20 <https://github.com/udayvir-singh/tangerine.nvim/issues/20> for more
-information.
+[!IMPORTANT] > - If you are using lazy.nvim
+<https://github.com/folke/lazy.nvim> then you should create `init.lua` instead
+of `plugin/0-tangerine.lua`. Refer to #20
+<https://github.com/udayvir-singh/tangerine.nvim/issues/20> for more
+information. > - If you are using rocks.nvim
+<https://github.com/nvim-neorocks/rocks.nvim>, there is no need to bootstrap
+this plugin (unless you want to write your rocks.nvim bootstrap script in
+Fennel). Install with `:Rocks install tangerine.nvim` and skip to step 2.
 
 >lua
     -- ~/.config/nvim/plugin/0-tangerine.lua or ~/.config/nvim/init.lua


### PR DESCRIPTION
Hey :wave: 

### Summary

This PR is part of a push to get neovim plugins on [luarocks.org](https://luarocks.org/labels/neovim).

See also:

- [rocks.nvim](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.
- [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html).

### Things done:

- Added a workflow that publishes tags to luarocks.org when a tag or release is pushed.
- Added note about using with rocks.nvim to the readme

See also: [this guide](https://github.com/nvim-neorocks/sample-luarocks-plugin)

### Notes:

> [!IMPORTANT]
> 
> - **For the luarocks workflow to work, someone with a luarocks.org account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository)**.

- Tagged releases are installed locally and then published to luarocks.org.
  - If you push tags from a local checkout, the workflow is triggered automatically.
  - If you use GitHub releases to create tags, you may need to [add a PA token](https://github.com/nvim-neorocks/sample-luarocks-plugin?tab=readme-ov-file#generating-a-pat-personal-access-token) for the workflow to be triggered automatically.
- Due to a shortcoming in luarocks.org (https://github.com/luarocks/luarocks-site/issues/188), the `neovim` and/or `vim` labels have to be added  to the luarocks package manually (after the first upload), for this plugin to show up in https://luarocks.org/labels/neovim or https://luarocks.org/labels/vim, respectively.