### PR TITLE
[vim]: replace deprecated vim.tbl_islist with vim.islist

### DIFF
--- a/fnl/tangerine/output/logger.fnl
+++ b/fnl/tangerine/output/logger.fnl
@@ -17,7 +17,7 @@
 ;; -------------------- ;;
 (lambda empty? [list]
   "checks if 'list' is empty."
-  (if (not (vim.tbl_islist list))
+  (if (not (vim.islist list))
       (error (.. "[tangerine]: error in logger, expected 'list' to be a valid list got " (type list) ".")))
   :return
   (= (length list) 0))

--- a/fnl/tangerine/utils/env.fnl
+++ b/fnl/tangerine/utils/env.fnl
@@ -31,14 +31,14 @@
 
 (lambda get-type [x]
   "returns type of x, correctly types lists."
-  (if (vim.tbl_islist x)
+  (if (vim.islist x)
       (do "list")
       (type x)))
 
 (lambda table? [tbl scm]
   "checks if 'tbl' is a valid table and 'scm' is not a list."
   (and (= :table (type tbl))
-       (not (vim.tbl_islist scm))))
+       (not (vim.islist scm))))
 
 (lambda deepcopy [tbl1 tbl2]
   "deep copy 'tbl1' onto 'tbl2'."

--- a/lua/tangerine/output/logger.lua
+++ b/lua/tangerine/output/logger.lua
@@ -6,7 +6,7 @@ local hl_failure = env.get("highlight", "errors")
 local hl_float = env.get("highlight", "float")
 local function empty_3f(list)
   _G.assert((nil ~= list), "Missing argument list on fnl/tangerine/output/logger.fnl:18")
-  if not vim.tbl_islist(list) then
+  if not vim.islist(list) then
     error(("[tangerine]: error in logger, expected 'list' to be a valid list got " .. type(list) .. "."))
   else
   end

--- a/lua/tangerine/utils/env.lua
+++ b/lua/tangerine/utils/env.lua
@@ -43,7 +43,7 @@ local function rtpdirs(dirs)
 end
 local function get_type(x)
   _G.assert((nil ~= x), "Missing argument x on fnl/tangerine/utils/env.fnl:32")
-  if vim.tbl_islist(x) then
+  if vim.islist(x) then
     return "list"
   else
     return type(x)
@@ -52,7 +52,7 @@ end
 local function table_3f(tbl, scm)
   _G.assert((nil ~= scm), "Missing argument scm on fnl/tangerine/utils/env.fnl:38")
   _G.assert((nil ~= tbl), "Missing argument tbl on fnl/tangerine/utils/env.fnl:38")
-  return (("table" == type(tbl)) and not vim.tbl_islist(scm))
+  return (("table" == type(tbl)) and not vim.islist(scm))
 end
 local function deepcopy(tbl1, tbl2)
   _G.assert((nil ~= tbl2), "Missing argument tbl2 on fnl/tangerine/utils/env.fnl:43")


### PR DESCRIPTION
Replace all `vim.tbl_islist` (deprecated name) with its modern equivalent, `vim.islist`.

This also silences the warning that is displayed whenever anything is printed from Fennel.